### PR TITLE
fix: correct phantomjs src package to a valid updated url

### DIFF
--- a/buildout-linux-x86.cfg
+++ b/buildout-linux-x86.cfg
@@ -2,4 +2,4 @@
 extends = buildout.cfg
 
 [phantomjs]
-url = https://phantomjs.googlecode.com/files/phantomjs-1.9.0-linux-i686.tar.bz2
+url = https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/phantomjs/phantomjs-1.9.2-linux-i686.tar.bz2

--- a/buildout-linux-x86_64.cfg
+++ b/buildout-linux-x86_64.cfg
@@ -2,4 +2,4 @@
 extends = buildout.cfg
 
 [phantomjs]
-url = https://phantomjs.googlecode.com/files/phantomjs-1.9.0-linux-x86_64.tar.bz2
+url = https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/phantomjs/phantomjs-1.9.2-linux-x86_64.tar.bz2

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -10,7 +10,7 @@ parts =
 recipe = gp.recipe.node
 npms = xmlrpc@0.9.4 socket.io@0.8.7 optimist coffee-script
 scripts = node coffee
-url = http://nodejs.org/dist/v0.10.1/node-v0.10.1.tar.gz
+url = http://nodejs.org/dist/v0.12.15/node-v0.12.15.tar.gz
 
 [phantomjs]
 recipe = hexagonit.recipe.download

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -14,7 +14,7 @@ url = http://nodejs.org/dist/v0.10.1/node-v0.10.1.tar.gz
 
 [phantomjs]
 recipe = hexagonit.recipe.download
-url = https://phantomjs.googlecode.com/files/phantomjs-1.9.0-macosx.zip
+url = https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/phantomjs/phantomjs-1.9.2-macosx.zip
 strip-top-level-dir = true
 
 [phantomjs-bin]


### PR DESCRIPTION
The current url in build.cfg is no longer valid.